### PR TITLE
Fix displayed chunk number being > numChunks for last chunk.

### DIFF
--- a/TransferLogic.cs
+++ b/TransferLogic.cs
@@ -819,7 +819,7 @@ public class TransferLogic
 
 			Console.ForegroundColor = ConsoleColor.Green;
 			int percent = (i + 1) * 100 / (inBytes.Length);
-			Console.Write("\r Sending chunk {0} of {1} ({2})%", (i / chunkSize) + 1, numChunks, percent);
+			Console.Write("\r Sending chunk {0} of {1} ({2})%", ((i / chunkSize) + 1) > numChunks ? numChunks : ((i / chunkSize) + 1), numChunks, percent);
 
 			SetDefaultColour();
 


### PR DESCRIPTION
Because of this : 
https://github.com/JonathanDotCel/NOTPSXSerial/blob/cfcd890cc839336f3194ca3fcbd94b327a6f8409/TransferLogic.cs#L802-L803
`chunkSize` can become very small and 
https://github.com/JonathanDotCel/NOTPSXSerial/blob/cfcd890cc839336f3194ca3fcbd94b327a6f8409/TransferLogic.cs#L822 
will result in a false value for the last occurence, i.e :
```bash
Got response: OKAY
 Sending chunk 1 of 5 (0)% ... Sending checksum...MORE DONE
 Sending chunk 2 of 5 (22)% ... Sending checksum...MORE DONE
 Sending chunk 3 of 5 (44)% ... Sending checksum...MORE DONE
 Sending chunk 4 of 5 (66)% ... Sending checksum...MORE DONE
 Sending chunk 9 of 5 (88)% ... Sending checksum...MORE DONE
```